### PR TITLE
Tweaks

### DIFF
--- a/after-remove.sh
+++ b/after-remove.sh
@@ -2,4 +2,4 @@
 
 # remove /opt/cs50/bin/submit50 and any empty parents
 rm -f /opt/cs50/bin/submit50
-rmdir --ignore-fail-on-non-empty -p /opt/cs50/bin
+rm -df /opt/cs50/bin /opt/cs50

--- a/opt/cs50/submit50/bin/submit50.py
+++ b/opt/cs50/submit50/bin/submit50.py
@@ -201,10 +201,7 @@ def submit(problem):
     username, password, email = authenticate()
 
     # show the spinner
-    if not run.verbose:
-        spin.keep_spinning = True
-        thread = Thread(target=spin, args=("Logging in... ",))
-        thread.start()
+    spin(msg="Logging in... ")
 
     # check for submit50 repository
     res = requests.get("https://api.github.com/repos/{}/{}".format(ORG_NAME, username), auth=(username, password))
@@ -236,9 +233,7 @@ def submit(problem):
     other = run("git ls-files --other").decode("utf-8").split()
 
     # stop the spinner
-    if not run.verbose:
-        spin.keep_spinning = False
-        thread.join()
+    spin(False)
 
     # files that will be submitted
     if len(files) == 0:
@@ -258,10 +253,7 @@ def submit(problem):
         raise Error("No files were submitted.") from None
 
     # show the spinner
-    if not run.verbose:
-        spin.keep_spinning = True
-        thread = Thread(target=spin)
-        thread.start()
+    spin()
 
     # push changes
     run("git commit --allow-empty --message='{}'".format(timestamp))
@@ -277,9 +269,7 @@ def submit(problem):
     run("git push --force origin 'refs/tags/{}'".format(tag), password=password)
 
     # stop the spinner
-    if not run.verbose:
-        spin.keep_spinning = False
-        thread.join()
+    spin(False)
 
     print(termcolor.colored("Submitted {}! See https://github.com/{}/{}/tree/{}.".format(
         problem, ORG_NAME, username, branch), "green"))
@@ -433,18 +423,25 @@ def two_factor():
 two_factor.auth = None
 two_factor.token = None
 
-def spin(message="Submitting... "):
-    spinner = itertools.cycle(["-", "\\", "|", "/"])
-    sys.stdout.write(message)
-    sys.stdout.flush()
-    while spin.keep_spinning:
-        sys.stdout.write(next(spinner))
+def spin(spinning=True, msg="Submitting... "):
+    spin.spinning = spinning
+    if run.verbose or not spinning:
+        return hasattr(spin, "thread") and spin.thread.join()
+
+    def spin_helper():
+        spinner = itertools.cycle(["-", "\\", "|", "/"])
+        sys.stdout.write(msg)
         sys.stdout.flush()
-        sys.stdout.write("\b")
-        time.sleep(0.05)
-    sys.stdout.write("\r")
-    sys.stdout.flush()
-spin.keep_spinning = True
+        while spin.spinning:
+            sys.stdout.write(next(spinner))
+            sys.stdout.flush()
+            sys.stdout.write("\b")
+            time.sleep(0.05)
+        sys.stdout.write("\r")
+        sys.stdout.flush()
+
+    spin.thread = Thread(target=spin_helper)
+    spin.thread.start()
 
 def usage():
     """Print usage."""

--- a/opt/cs50/submit50/bin/submit50.py
+++ b/opt/cs50/submit50/bin/submit50.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+import atexit
 import datetime
 import getch
 import http.client
@@ -39,6 +40,9 @@ def main():
 
     # listen for ctrl-c
     signal.signal(signal.SIGINT, handler)
+
+    # clean up on normal exit
+    atexit.register(teardown)
 
     # check for version
     res = requests.get("https://raw.githubusercontent.com/{0}/{0}/master/VERSION".format(ORG_NAME))
@@ -152,7 +156,6 @@ sys.excepthook = excepthook
 
 def handler(number, frame):
     """Handle SIGINT."""
-    teardown()
     print()
     sys.exit(0)
 
@@ -278,8 +281,6 @@ def submit(problem):
         spin.keep_spinning = False
         thread.join()
 
-    # successful submission
-    teardown()
     print(termcolor.colored("Submitted {}! See https://github.com/{}/{}/tree/{}.".format(
         problem, ORG_NAME, username, branch), "green"))
 
@@ -364,8 +365,6 @@ def checkout(args):
             else:
                 run("git checkout -b '{}'".format(problem), cwd=name, env={})
                 run("git rm -rf .", cwd=name, env={})
-
-    teardown()
 
 def run(command, password=None, cwd=None, env=None):
     """Run a command."""


### PR DESCRIPTION
A couple of slight changes that might be of interest?

* Re `teardown`, a temp directory was always created, but not cleaned up sometimes (e.g., in case of invalid usage).
 
* Re `rmdir`, per Asana, it used to end up putting the deb package in inconsistent state while trying to uninstall, since it would try to remove `/` after removing empty `/opt/`. Typically, there's other stuff under `/opt`, but feels better to fix this anyway (especially that it's quite annoying when trying to uninstall then reinstall in the container)?

cc @dmalan @brianyu28 