### PR TITLE
Checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAINTAINER = "CS50 <sysadmins@cs50.harvard.edu>"
 NAME = submit50
-VERSION = 2.1.1
+VERSION = 2.1.2
 
 .PHONY: bash
 bash:

--- a/opt/cs50/submit50/bin/submit50.py
+++ b/opt/cs50/submit50/bin/submit50.py
@@ -27,7 +27,7 @@ from threading import Thread
 
 EXCLUDE = None
 ORG_NAME = "submit50"
-VERSION = "2.1.0"
+VERSION = "2.1.2"
 timestamp = ""
 
 class Error(Exception):

--- a/opt/cs50/submit50/bin/submit50.py
+++ b/opt/cs50/submit50/bin/submit50.py
@@ -337,7 +337,7 @@ def checkout(args):
                 continue
             if not url.startswith("https://{}@github.com/{}/".format(username, ORG_NAME)):
                 print("Invalid repo: {}".format(name))
-            run("git pull", cwd=name, env={})
+            run("git pull", cwd=name, password=password, env={})
         else:
             # clone repository if it doesn't already exist
             run("git clone 'https://{}@github.com/{}/{}' '{}'".format(username, ORG_NAME, name, name), password=password, env={})

--- a/opt/cs50/submit50/bin/submit50.py
+++ b/opt/cs50/submit50/bin/submit50.py
@@ -337,7 +337,14 @@ def checkout(args):
                 continue
             if not url.startswith("https://{}@github.com/{}/".format(username, ORG_NAME)):
                 print("Invalid repo: {}".format(name))
-            run("git pull", cwd=name, password=password, env={})
+
+            # fetch new branches
+            # http://stackoverflow.com/a/11958481
+            # http://stackoverflow.com/a/26339690
+            run("git fetch --all", cwd=name, password=password, env={})
+            _, code = pexpect.run("git config --get branch.$(git symbolic-ref --short -q HEAD).merge", cwd=name, env={}, withexitstatus=True)
+            if code == 0:
+                run("git pull", cwd=name, password=password, env={})
         else:
             # clone repository if it doesn't already exist
             run("git clone 'https://{}@github.com/{}/{}' '{}'".format(username, ORG_NAME, name, name), password=password, env={})
@@ -360,7 +367,9 @@ def checkout(args):
                 run("git checkout '{}'".format(problem), cwd=name, env={})
             else:
                 run("git checkout -b '{}'".format(problem), cwd=name, env={})
-                run("git rm -rf .", cwd=name, env={})
+                files = run("git ls-files", cwd=name, env={})
+                if files:
+                    run("git rm -rf .", cwd=name, env={})
 
     teardown()
 


### PR DESCRIPTION
@dmalan, @dlloyd09, @Erin-c

The problems were:

- `git pull` seems to require a password when trying to pull via HTTPS from a repository to which a user has pull-only access. Now, the call to `git pull` provides the user's password.
- `git pull` also fails when there's no tracking information for the current branch (e.g. TF checks out `mario`, but one student never submitted `mario`, so when the TF then checks out `greedy`, that one student's repo fails on `git pull`). Solution to this is to first `git fetch`, and then only `git pull` only if there's a remote tracking branch.
- `git rm -rf .` fails when there's no files in the branch to `git rm` (again, happens any time there's a student who didn't submit anything for a problem). Solution is to check that `git ls-files` has some output before the call to `git rm -rf .`
