### PR TITLE
requires requests and reads version programmatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
         "Topic :: Utilities"
     ],
     description="This is submit50, with which you can submit solutions to problems for CS50.",
-    install_requires=["getch", "pexpect", "termcolor"],
+    install_requires=["getch", "pexpect", "requests", "termcolor"],
     keywords=["submit", "submit50"],
     name="submit50",
     scripts=["submit50"],
     url="https://github.com/cs50/submit50",
-    version="2.1.4"
+    version="2.1.5"
 )

--- a/submit50
+++ b/submit50
@@ -23,11 +23,11 @@ import time
 import traceback
 import urllib.request
 
-from distutils.version import StrictVersion
+from pkg_resources import get_distribution, parse_version
 from threading import Thread
 
 ORG_NAME = "submit50"
-VERSION = "2.1.4"
+__version__ = get_distribution("submit50").version
 timestamp = ""
 
 class Error(Exception):
@@ -48,7 +48,7 @@ def main():
     if res.status_code != 200:
         raise Error("You have an unknown version of submit50. Email sysadmins@cs50.harvard.edu.") from None
     version_required = res.text.strip()
-    if StrictVersion(version_required) > StrictVersion(VERSION):
+    if parse_version(version_required) > parse_version(__version__):
         raise Error("You have an old version of submit50. Run update50, then re-run submit50!") from None
 
     # compute timestamp


### PR DESCRIPTION
After a little bit more searching, turns out there's a simpler way to read the version number specified in `setup.py`, which should work for our purposes.

This PR also adds `requests` as dependency. Noticed it was missing while testing in a venv.

Thoughts, @dmalan @brianyu28?