### PR TITLE
bumps version and deploys on tags only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ deploy:
   # deploy to PyPI
   - provider: script
 
-  # upload sdist to PyPI
-  script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
+    # upload sdist to PyPI
+    script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 
-  # avoid stashing sdist
-  skip_cleanup: true
+    # avoid stashing sdist
+    skip_cleanup: true
 
-  # deploy on tags only
-  on:
-    tags: true
+    # deploy on tags only
+    on:
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ before_deploy: pip install twine
 deploy:
   provider: script
 
+  # deploy on tags only
+  on:
+    tags: true
+
   # upload to PyPI
   script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,36 @@ script: make build
 before_deploy: pip install twine
 
 deploy:
-  provider: script
 
-  # deploy on tags only
-  on:
-    tags: true
+  # create github release
+  - provider: releases
 
-  # upload to PyPI
+    # GitHub access token
+    api_key:
+      secure: "Hv2ICkPkC7hiRw8GS9adkEcfoYGeVPbGHRNPQdGxLTeP1Mz9x/2ylUprrb2Ohq+pHGRa1W55nSJAZWHto4L/seWS17vN1JB1o71KYeD8h4Ywm/iJzYJFu4v8cmuT9qMPC89GtSGUkEZml+Vd6lb6d/eBr7HWoAMF7LCobzVvpJftgSBqkN1Z0aaunGNRtPVaqf0D4iQMSU1e0X9HFyIsxjS68sNqVcU/eSqbkHQ32COliOdEZXDqNmoJjIq4NYVH7DCS4kSpfxSd3BkJPn1UH4891MntflMllH7khmSA0lqSuunp+olfzhzchYb0/e0LavqYyFU/cRemyt8RBuE0GD3J3TMudVav/5HLKt6/exZwqfv7bHyorDXkkKGJqYNPUCOD2K4RS4ExpUU5c5en5inJZdgKYVI9gZS15oXmKV3H/8JkJPgx0xRP1Rx8niQKezKdFb0dZxArbMBUuAnolgyoq2EgnsNYhboRWXoJP36FCWFn8U8UNUfmgOkkMcP59mZ6svznxWPIyCMhfGgShY03GTvPp94P6c6OZJpjyjmWyPsvGZJrvnRlJ8VxBaUBcfuQl9rtBorwJ3VI1VWguyBaSINM6OWPtEJ0J2oVM/8Dvjuw2qPNkCdUhflc7wV/AUYB9/6rfpjY+GwTEKtZBBw4epbZX/B0L+vdRONZJ0Q="
+
+    # enable wildcards in filenames
+    file_glob: true
+
+    # upload sdist
+    file: dist/*
+
+    # avoid stashing sdist
+    skip_cleanup: true
+
+    # create releases on tags only
+    on:
+      tags: true
+
+  # deploy to PyPI
+  - provider: script
+
+  # upload sdist to PyPI
   script: twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 
   # avoid stashing sdist
   skip_cleanup: true
+
+  # deploy on tags only
+  on:
+    tags: true

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,15 @@ clean:
 
 .PHONY: install
 install: build
-	pip install dist/submit50*.tar.gz
+	pip3 install dist/*.tar.gz
+
+.PHONY: push
+push:
+	git push origin "v$$(python3 setup.py --version)"
+
+.PHONY: release
+release: tag push
+
+.PHONY: tag
+tag:
+	git tag "v$$(python3 setup.py --version)"

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(
     name="submit50",
     scripts=["submit50"],
     url="https://github.com/cs50/submit50",
-    version="2.1.5"
+    version="2.1.6"
 )


### PR DESCRIPTION
@dmalan we should probably publish to PyPI on tags rather than commits to master? This will give us a little more control over when to release a new version, and won't require us to bump the version number for every small tweak that's merged into master.

Alternatively, we may create a `production` branch or such, and only merge to that when a new version is ready to be deployed, having Travis deploy on commits to `production` instead.

cc @brianyu28 