### PR TITLE
added support for SSH keys, prefilling username

### DIFF
--- a/submit50.py
+++ b/submit50.py
@@ -504,12 +504,6 @@ def submit(org, problem):
     run("git commit --allow-empty --message='{}'".format(timestamp))
     run("git push origin 'refs/heads/{}'".format(branch), password=password)
 
-    # push tag
-    # http://stackoverflow.com/a/23486788
-    hash = run("git commit-tree HEAD^{{tree}} -m '{}'".format(timestamp))
-    hash = hash.strip()
-    run("git push origin {}:refs/tags/{}".format(hash, tag), password=password)
-
     # successful submission
     cprint("Submitted {}! ".format(problem) +
            "See https://cs50.me/submissions/{}.".format(branch),

--- a/submit50.py
+++ b/submit50.py
@@ -342,7 +342,7 @@ def spin(message=""):
 
     # start spinning if message passed
     if message != False:
-        def spin_helper():
+        def spin_helper(): # https://stackoverflow.com/a/4995896
             spinner = itertools.cycle(["-", "\\", "|", "/"])
             sys.stdout.write(message + "... ")
             sys.stdout.flush()

--- a/submit50.py
+++ b/submit50.py
@@ -369,7 +369,7 @@ def submit(org, problem):
     if not which("git"):
         raise Error("You don't have git. Install git, then re-run submit50!.")
     version = subprocess.check_output(["git", "--version"]).decode("utf-8")
-    matches = re.search(r"^git version (\d+\.\d+\.\d+)$", version)
+    matches = re.search(r"^git version (\d+\.\d+\.\d+).*$", version)
     if not matches or StrictVersion(matches.group(1)) < StrictVersion("2.7.0"):
         raise Error("You have an old version of git. Install version 2.7 or later, then re-run submit50!")
 

--- a/submit50.py
+++ b/submit50.py
@@ -438,8 +438,7 @@ def submit(org, problem):
         repo = "git@github.com:{}/{}.git".format(org, username)
         with open(os.devnull, "w") as DEVNULL:
             spin(False)
-            returncode = subprocess.call(["ssh", "git@github.com"], stderr=DEVNULL)
-            assert returncode == 1
+            assert subprocess.call(["ssh", "git@github.com"], stderr=DEVNULL) == 1 # successfully authenticated
 
     # authenticate user via HTTPS
     except:

--- a/submit50.py
+++ b/submit50.py
@@ -452,8 +452,13 @@ def submit(org, problem):
     try:
         run("git clone --bare {} {}".format(shlex.quote(repo), shlex.quote(run.GIT_DIR)), password=password)
     except:
-        e = Error("Looks like submit50 isn't enabled for your account yet. " +
-                  "Log into https://cs50.me/ in a browser, click \"Authorize application\", then re-run submit50 here!")
+        if password:
+            e = Error("Looks like submit50 isn't enabled for your account yet. " +
+                      "Log into https://cs50.me/ in a browser, click \"Authorize application\", and re-run submit50 here!")
+        else:
+            e = Error("Looks like you have the wrong username in ~/.gitconfig or submit50 isn't yet enabled for your account. " +
+                      "Double-check ~/.gitconfig and then log into https://cs50.me/ in a browser, " +
+                      "click \"Authorize application\" if prompted, and re-run submit50 here.")
         e.__cause__ = None
         raise e
 

--- a/submit50.py
+++ b/submit50.py
@@ -162,10 +162,12 @@ def authenticate(org):
            readline.set_startup_hook()
 
     # prompt for credentials
+    spin(False) # because not using cprint herein
     if not password:
 
         # prompt for username, prefilling if possible
         while True:
+            spin(False)
             username = rlinput("GitHub username: ", username).strip()
             if username:
                 break
@@ -177,18 +179,18 @@ def authenticate(org):
             while True:
                 ch = getch()
                 if ch in ["\n", "\r"]: # Enter
-                    cprint()
+                    print()
                     break
                 elif ch == "\177": # DEL
                     if len(password) > 0:
                         password = password[:-1]
-                        cprint("\b \b", end="", flush=True)
+                        print("\b \b", end="", flush=True)
                 elif ch == "\3": # ctrl-c
-                    cprint("^C", end="")
+                    print("^C", end="")
                     os.kill(os.getpid(), signal.SIGINT)
                 else:
                     password += ch
-                    cprint("*", end="", flush=True)
+                    print("*", end="", flush=True)
             if password:
                 break
 
@@ -222,10 +224,6 @@ def authenticate(org):
         "-c credentialcache.ignoresighup=true credential approve".format(socket, timeout),
         lines=["username={}".format(username), "password={}".format(password), "", ""],
         quiet=True)
-
-    # store username on disk
-    run("git config --global credential.https://github.com/{}.username {}".format(ORG, username))
-    run("git config --global credential.https://github.com/{}.useHttpPath true".format(ORG, username))
 
     # return credentials
     return (username, password, email)
@@ -327,7 +325,7 @@ run.verbose = False
 
 
 def spin(message=""):
-    """Displays a spinning message."""
+    """Display a spinning message."""
 
     # don't spin in verbose mode
     if run.verbose:

--- a/submit50.py
+++ b/submit50.py
@@ -432,6 +432,7 @@ def submit(org, problem):
 
     # authenticate user via SSH
     try:
+        assert which("ssh")
         username, password = run("git config --global credential.https://github.com/submit50.username", quiet=True), None
         email = "{}@users.noreply.github.com".format(username)
         repo = "git@github.com:{}/{}.git".format(org, username)


### PR DESCRIPTION
If a user hasn't logged in recently and thus their credentials aren't cached in `~/.git-credential-cache`, `submit50` now checks `~/.gitconfig` to see if they have a default username specified for `https://github.com/submit50`, in which case the `GitHub username: ` prompt is pre-filled with that value, which they can then accept or edit.

And if a user indeed has a default username specified for `https://github.com/submit50` in `~/.gitconfig`, `submit50` also now tries to connect via SSH to GitHub; if it succeeds, SSH is used instead of HTTPS.

To configure `~/.gitconfig` with a default username, a user can run, e.g.:

```
git config --global credential.https://github.com/submit50.username jharvard
git config --global credential.https://github.com/submit50.useHttpPath true
```

Or the user can manually edit `~/.gitconfig` as follows:

```
[credential "https://github.com/submit50"]
    username = jharvard
    useHttpPath = true
```