### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,6 @@ python:
 - '3.4'
 branches:
   except: "/^v\\d/"
-addons:
-  apt:
-    sources:
-    - sourceline: "ppa:git-core/ppa"
-    packages:
-    - git
 install: true
 script:
 - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
 - '2.7'
 - '3.4'
+dist: trusty
+sudo: false
 branches:
   except: "/^v\\d/"
 install: true


### PR DESCRIPTION
Using trusty containers which have `git` v2.13 installed now per https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch, so no need to install manually.