### PR TITLE
replaces spinner with progress dots

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,5 +61,5 @@ setup(
         "console_scripts": ["submit50=submit50:main"]
     },
     url="https://github.com/cs50/submit50",
-    version="2.3.0"
+    version="2.3.1"
 )

--- a/submit50.py
+++ b/submit50.py
@@ -162,12 +162,12 @@ def authenticate(org):
            readline.set_startup_hook()
 
     # prompt for credentials
-    spin(False) # because not using cprint herein
+    progress(False) # because not using cprint herein
     if not password:
 
         # prompt for username, prefilling if possible
         while True:
-            spin(False)
+            progress(False)
             username = rlinput("GitHub username: ", username).strip()
             if username:
                 break
@@ -232,8 +232,8 @@ def authenticate(org):
 def cprint(text="", color=None, on_color=None, attrs=None, **kwargs):
     """Colorizes text (and wraps to terminal's width)."""
 
-    # stop spinner (if spinning)
-    spin(False)
+    # update progress
+    progress(False)
 
     # assume 80 in case not running in a terminal
     columns, _ = get_terminal_size()
@@ -251,7 +251,7 @@ def cprint(text="", color=None, on_color=None, attrs=None, **kwargs):
 def excepthook(type, value, tb):
     """Report an exception."""
     excepthook.ignore = False
-    spin(False)
+    progress(False)
     teardown()
     if type is Error and str(value):
         cprint(str(value), "yellow")
@@ -270,8 +270,8 @@ sys.excepthook = excepthook
 def handler(number, frame):
     """Handle SIGINT."""
     os.system("stty sane") # in case signalled from input_with_prefill
-    if spin.spinning:
-        spin(False)
+    if progress.progressing:
+        progress(False)
     else:
         cprint()
     cprint("Submission cancelled.", "red")
@@ -326,39 +326,37 @@ run.GIT_WORK_TREE = os.getcwd()
 run.verbose = False
 
 
-def spin(message=""):
-    """Display a spinning message."""
+def progress(message=""):
+    """Display a progress bar as dots."""
 
-    # don't spin in verbose mode
+    # don't show in verbose mode
     if run.verbose:
         if message != False:
             print(message + "...")
         return
 
-    # stop spinning if already spinning
-    if spin.spinning:
-        spin.spinning = False
-        spin.thread.join()
+    # stop progressing if already progressing
+    if progress.progressing:
+        progress.progressing = False
+        progress.thread.join()
+        sys.stdout.write("\n")
+        sys.stdout.flush()
 
-    # start spinning if message passed
+    # display dots if message passed
     if message != False:
-        def spin_helper(): # https://stackoverflow.com/a/4995896
-            spinner = itertools.cycle(["-", "\\", "|", "/"])
-            sys.stdout.write(message + "... ")
+        def progress_helper(): # https://stackoverflow.com/a/4995896
+            sys.stdout.write(message + "...")
             sys.stdout.flush()
-            while spin.spinning:
-                sys.stdout.write(next(spinner))
+            while progress.progressing:
+                sys.stdout.write(".")
                 sys.stdout.flush()
-                sys.stdout.write("\b")
-                time.sleep(0.1)
-            sys.stdout.write("\033[2K\r")
-            sys.stdout.flush()
-        spin.spinning = True
-        spin.thread = Thread(target=spin_helper)
-        spin.thread.start()
+                time.sleep(0.5)
+        progress.progressing = True
+        progress.thread = Thread(target=progress_helper)
+        progress.thread.start()
 
 
-spin.spinning = False
+progress.progressing = False
 
 
 def submit(org, problem):
@@ -371,10 +369,11 @@ def submit(org, problem):
     version = subprocess.check_output(["git", "--version"]).decode("utf-8")
     matches = re.search(r"^git version (\d+\.\d+\.\d+).*$", version)
     if not matches or StrictVersion(matches.group(1)) < StrictVersion("2.7.0"):
-        raise Error("You have an old version of git. Install version 2.7 or later, then re-run submit50!")
+        raise Error("You have an old version of git. Install version 2.7 or later, " +
+                    "then re-run submit50!")
 
-    # update spinner
-    spin("Connecting")
+    # update progress
+    progress("Connecting")
 
     # compute timestamp
     global timestamp
@@ -427,8 +426,8 @@ def submit(org, problem):
             cprint(" {}".format(pattern))
         raise Error("Ensure you have the required files before submitting.")
 
-    # update spinner
-    spin("Authenticating")
+    # update progress
+    progress("Authenticating")
 
     # authenticate user via SSH
     try:
@@ -437,7 +436,7 @@ def submit(org, problem):
         email = "{}@users.noreply.github.com".format(username)
         repo = "git@github.com:{}/{}.git".format(org, username)
         with open(os.devnull, "w") as DEVNULL:
-            spin(False)
+            progress(False)
             assert subprocess.call(["ssh", "git@github.com"], stderr=DEVNULL) == 1 # successfully authenticated
 
     # authenticate user via HTTPS
@@ -445,8 +444,8 @@ def submit(org, problem):
         username, password, email = authenticate(org)
         repo = "https://{}@github.com/{}/{}".format(username, org, username)
 
-    # update spinner
-    spin("Preparing")
+    # update progress
+    progress("Preparing")
 
     # clone repository
     try:
@@ -497,8 +496,8 @@ def submit(org, problem):
     if not re.match("^\s*(?:y|yes)\s*$", input(), re.I):
         raise Error("No files were submitted.")
 
-    # restart spinner
-    spin("Submitting")
+    # update progress
+    progress("Submitting")
 
     # push branch
     run("git commit --allow-empty --message='{}'".format(timestamp))

--- a/submit50.py
+++ b/submit50.py
@@ -344,7 +344,7 @@ def progress(message=""):
 
     # display dots if message passed
     if message != False:
-        def progress_helper(): # https://stackoverflow.com/a/4995896
+        def progress_helper():
             sys.stdout.write(message + "...")
             sys.stdout.flush()
             while progress.progressing:


### PR DESCRIPTION
So I realized today that our fancy spinner and line-clearing really isn't consistent with other command-line tools students will use. And it can be disorienting if you haven't yet read/understood a message before it disappears. So this reintroduces check50 v1's progress dots, a la the below. @brianyu28, what do you think? This way too, we can infer from screenshots and copy/pastes of output about how long a command took for a student, per your remark the other day.

```
$ submit50 problem
Connecting....
Authenticating.....
GitHub username: jharvard
GitHub password: *******
Authentication code: ######
Preparing........
Files that will be submitted:
./hello.c
Keeping in mind the course's policy on academic honesty, are you sure you want to submit these files? y
Submitting.........
Submitted develop! See https://cs50.me/submissions/problem.
```