### PR TITLE
Solve halting problem

### DIFF
--- a/submit50.py
+++ b/submit50.py
@@ -139,21 +139,22 @@ def authenticate(org):
         pass
     authenticate.SOCKET = os.path.join(cache, ORG)
 
-    # check cache, then config for credentials
-    credentials = run("git -c credential.helper='cache --socket {}' credential fill".format(authenticate.SOCKET),
-                      lines=[""]*3,
-                      quiet=True)
-    run("git credential-cache --socket {} exit".format(authenticate.SOCKET))
-    matches = re.search("^username=([^\r]+)\r\npassword=([^\r]+)\r?$", credentials, re.MULTILINE)
-    if matches:
-        username = matches.group(1)
-        password = matches.group(2)
+    spawn = pexpect.spawn if sys.version_info < (3, 0) else pexpect.spawnu
+    child = spawn("git -c credential.helper='cache --socket {}' credential fill".format(authenticate.SOCKET))
+    child.sendline("")
+
+    if child.expect(["Username:", pexpect.EOF]):
+        # Credentials are already cached
+        clear_credentials()
+        username, password = re.search("username=([^\r]+)\r\npassword=([^\r]+)", child.before, re.MULTILINE).groups()
     else:
+        # No cached credentials found
         try:
             username = run("git config --global credential.https://github.com/submit50.username")
-        except:
+        except Error:
             username = None
         password = None
+    child.close()
 
     def rlinput(prompt, prefill=""):
         """
@@ -238,6 +239,16 @@ def authenticate(org):
 authenticate.SOCKET = None
 
 
+def clear_credentials():
+    """Clear git credential cache """
+    run("git credential-cache --socket {} exit".format(authenticate.SOCKET))
+    # OSX will sometimes store git credentials in the keyring. Try to remove them
+    try:
+        run("git credential-osxkeychain erase", lines=["host=github.com", "protocol=https", ""])
+    except Error:
+        pass
+
+
 def cprint(text="", color=None, on_color=None, attrs=None, **kwargs):
     """Colorizes text (and wraps to terminal's width)."""
 
@@ -271,7 +282,7 @@ def excepthook(type, value, tb):
             traceback.print_exception(type, value, tb)
         cprint(_("Sorry, something's wrong! Let sysadmins@cs50.harvard.edu know!"), "yellow")
     try:
-        run("git credential-cache --socket {} exit".format(authenticate.SOCKET))
+        clear_credentials()
     except Exception:
         pass
     cprint(_("Submission cancelled."), "red")
@@ -282,13 +293,13 @@ sys.excepthook = excepthook
 
 def handler(number, frame):
     """Handle SIGINT."""
-    os.system("stty sane") # in case signalled from input_with_prefill
+    os.system("stty sane 2> {}".format(os.devnull)) # in case signalled from input_with_prefill
     if progress.progressing:
         progress(False)
     else:
         cprint()
     try:
-        run("git credential-cache --socket {} exit".format(authenticate.SOCKET))
+        clear_credentials()
     except Exception:
         pass
     teardown()
@@ -296,7 +307,7 @@ def handler(number, frame):
     os._exit(0)
 
 
-def run(command, cwd=None, env=None, lines=[], password=None, quiet=False):
+def run(command, cwd=None, env=None, lines=[], password=None, quiet=False, timeout=None):
     """Run a command."""
 
     # echo command
@@ -313,9 +324,9 @@ def run(command, cwd=None, env=None, lines=[], password=None, quiet=False):
 
     # spawn command
     if sys.version_info < (3, 0):
-        child = pexpect.spawn(command, cwd=cwd, env=env, ignore_sighup=True, timeout=None)
+        child = pexpect.spawn(command, cwd=cwd, env=env, ignore_sighup=True, timeout=timeout)
     else:
-        child = pexpect.spawnu(command, cwd=cwd, encoding="utf-8", env=env, ignore_sighup=True, timeout=None)
+        child = pexpect.spawnu(command, cwd=cwd, encoding="utf-8", env=env, ignore_sighup=True, timeout=timeout)
 
     # send output of command to stdout only if run with --verbose (and not quieted by caller)
     if run.verbose and not quiet:


### PR DESCRIPTION
This PR fixes issue #112 where pexpect would not halt when querying `git credential-cache`.

Additionally, it will attempt to run `git credential-osxkeychain erase` to ensure that the credential cache is indeed cleared on OSX.