### PR TITLE
fixed support for unicode chars in filenames, fixed LFS, other tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,5 @@ problems for CS50.",
     },
     data_files=create_mo_files(),
     url="https://github.com/cs50/submit50",
-    version="2.4.5"
+    version="2.4.6"
 )

--- a/submit50.py
+++ b/submit50.py
@@ -331,8 +331,6 @@ def run(command, cwd=None, env=None, lines=[], password=None, quiet=False, timeo
             env["SSH_AUTH_SOCK"] = os.getenv("SSH_AUTH_SOCK")
 
     # spawn command
-    print("ENV:")
-    print(env)
     if sys.version_info < (3, 0):
         child = pexpect.spawn(command, cwd=cwd, env=env, ignore_sighup=True, timeout=timeout)
     else:

--- a/submit50.py
+++ b/submit50.py
@@ -623,6 +623,7 @@ def submit(org, branch):
                 cprint("./{}".format(f), "yellow")
 
         # prompt for honesty
+        readline.clear_history()
         try:
             answer = input(_("Keeping in mind the course's policy on academic honesty, "
                              "are you sure you want to submit these files (yes/no)? "))

--- a/submit50.py
+++ b/submit50.py
@@ -175,42 +175,36 @@ def authenticate(org):
     if not password:
 
         # prompt for username, prefilling if possible
-        while True:
-            progress(False)
-            try:
-                username = rlinput(_("GitHub username: "), username).strip()
-                if username:
-                    break
-            except EOFError:
-                print()
+        progress(False)
+        try:
+            username = rlinput(_("GitHub username: "), username).strip()
+        except EOFError:
+            print()
 
         # prompt for password
+        print(_("GitHub password: "), end="")
+        sys.stdout.flush()
+        password = str()
         while True:
-            print(_("GitHub password: "), end="")
-            sys.stdout.flush()
-            password = str()
-            while True:
-                ch = getch()
-                if ch in ["\n", "\r"]:  # Enter
-                    print()
-                    break
-                elif ch == "\177":  # DEL
-                    if len(password) > 0:
-                        password = password[:-1]
-                        print("\b \b", end="")
-                        sys.stdout.flush()
-                elif ch == "\3":  # ctrl-c
-                    print("^C", end="")
-                    os.kill(os.getpid(), signal.SIGINT)
-                elif ch == "\4":  # ctrl-d
-                    print()
-                    break
-                else:
-                    password += ch
-                    print("*", end="")
-                    sys.stdout.flush()
-            if password:
+            ch = getch()
+            if ch in ["\n", "\r"]:  # Enter
+                print()
                 break
+            elif ch == "\177":  # DEL
+                if len(password) > 0:
+                    password = password[:-1]
+                    print("\b \b", end="")
+                    sys.stdout.flush()
+            elif ch == "\3":  # ctrl-c
+                print("^C", end="")
+                os.kill(os.getpid(), signal.SIGINT)
+            elif ch == "\4":  # ctrl-d
+                print()
+                break
+            else:
+                password += ch
+                print("*", end="")
+                sys.stdout.flush()
 
     # authenticate user
     email = "{}@users.noreply.github.com".format(username)

--- a/submit50.py
+++ b/submit50.py
@@ -562,8 +562,8 @@ def submit(org, branch):
     run("git add --all")
 
     # get file lists
-    files = run("git ls-files").splitlines()
-    other = run("git ls-files --exclude-standard --other").splitlines()
+    files = run("git -c core.quotepath=off ls-files").splitlines()
+    other = run("git -c core.quotepath=off ls-files --exclude-standard --other").splitlines()
 
     # check for large files > 100 MB (and huge files > 2 GB)
     # https://help.github.com/articles/conditions-for-large-files/


### PR DESCRIPTION
@glennholloway, would you mind testing this `unicode` branch on a Windows machine by trying to submit an empty file with Unicode characters in its name? E.g.:

```
mkdir tmp
cd tmp
touch "training完成後.txt"
submit50 develop
```

This fixes an issue on Mac OS / Linux, whereby `git-ls-files` was returning filenames with octal escape codes (e.g., the above becomes `"training\345\256\214\346\210\220\345\276\214.txt"`, which was then breaking `os.path.getsize`. But not sure how portable this might prove, https://stackoverflow.com/a/22828826/5156190.

@crossroads1112, @brianyu28, as an alternative, know how we can just convert the octal escape codes back to a Unicode string for `os.path.getsize`? 