### PR TITLE
quoted filename

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,5 @@ problems for CS50.",
     },
     data_files=create_mo_files(),
     url="https://github.com/cs50/submit50",
-    version="2.4.7"
+    version="2.4.8"
 )

--- a/submit50.py
+++ b/submit50.py
@@ -606,9 +606,9 @@ def submit(org, branch):
         run("git lfs install --local")
         run("git config credential.helper cache") # for pre-push hook
         for large in larges:
-            run("git rm --cached {}".format(large))
-            run("git lfs track {}".format(large))
-            run("git add {}".format(large))
+            run("git rm --cached {}".format(shlex.quote(large)))
+            run("git lfs track {}".format(shlex.quote(large)))
+            run("git add {}".format(shlex.quote(large)))
         run("git add --force .gitattributes")
 
     # files that will be submitted


### PR DESCRIPTION
Previously:

```
# create > 100M file with space in its name
$ dd if=/dev/zero of="foo bar" count=101 bs=1048576 
$ submit50 --verbose cs50/2018/x/project
Connecting...
Authenticating...
git config --global credential.https://github.com/submit50.username
git config --global credential.https://github.com/submit50.username
git -c credential.helper='cache --socket /home/kzidane/.git-credential-cache/submit50 --timeout 604800' -c credentialcache.ignoresighup=true credential approve
Preparing...
git clone --bare https://xxx@github.com/submit50/xxx /tmp/tmpfa15epkr
Cloning into bare repository '/tmp/tmpfa15epkr'...
Password for 'https://xxx@github.com': 
remote: Counting objects: 753, done.        
remote: Compressing objects: 100% (40/40), done.        
remote: Total 753 (delta 16), reused 30 (delta 2), pack-reused 709        
Receiving objects: 100% (753/753), 2.79 MiB | 5.56 MiB/s, done.
Resolving deltas: 100% (545/545), done.
git checkout --force cs50/2018/x/project .gitattributes
git config user.email xxx@users.noreply.github.com
git config user.name xxx
git symbolic-ref HEAD refs/heads/cs50/2018/x/project
git config core.excludesFile /tmp/tmptkelemcn
git add --all
git ls-files
.gitattributes
foo bar
git ls-files --exclude-from=/tmp/tmpfa15epkr/info/exclude --other
git lfs install --local
Updated git hooks.
Git LFS initialized.
git config credential.helper cache
git rm --cached foo bar
fatal: pathspec 'foo' did not match any files
Traceback (most recent call last):
  File "/home/kzidane/.virtualenvs/submit50/bin/submit50", line 11, in <module>
    sys.exit(main())
  File "/home/kzidane/.virtualenvs/submit50/lib/python3.6/site-packages/submit50.py", line 128, in main
    submit("submit50", args["slug"])
  File "/home/kzidane/.virtualenvs/submit50/lib/python3.6/site-packages/submit50.py", line 609, in submit
    run("git rm --cached {}".format(large))
  File "/home/kzidane/.virtualenvs/submit50/lib/python3.6/site-packages/submit50.py", line 369, in run
    raise Error()
submit50.Error
Sorry, something's wrong! Let sysadmins@cs50.harvard.edu know!
git credential-cache --socket /home/kzidane/.git-credential-cache/submit50 exit
Submission cancelled.
```