### PR TITLE
check for homebrew python vs regular python and install certifi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,5 @@ problems for CS50.",
     },
     data_files=create_mo_files(),
     url="https://github.com/cs50/submit50",
-    version="2.4.8"
+    version="2.4.9"
 )

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from subprocess import call
 from sys import platform, version_info
 
 requires = [
-        "backports.shutil_get_terminal_size", "backports.shutil_which",
-        "pexpect>=4.0", "requests", "six", "termcolor"
+    "backports.shutil_get_terminal_size", "backports.shutil_which", "pexpect>=4.0", "requests", 
+    "six", "termcolor"
 ]
 
 # install certifi under OS X

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,23 @@ from setuptools.command.install import install
 from subprocess import call
 from sys import platform, version_info
 
+requires = [
+        "backports.shutil_get_terminal_size", "backports.shutil_which",
+        "pexpect>=4.0", "requests", "six", "termcolor"
+]
+
+# check whether we have a Homebrew or Python installation of Python
+INSTALL_CERTS = "/Applications/Python 3.6/Install Certificates.command"
+HOMEBREW_PYTHON = "/usr/local/bin/python3"
+
+if platform == "darwin" and version_info >= (3, 6):
+    if not isfile(INSTALL_CERTS) or call(INSTALL_CERTS) != 0:
+        if not isfile(HOMEBREW_PYTHON):
+            raise RuntimeError("Install certificates not found and no Homebrew Python installed!")
+        else:
+            # certifi library installs needed certificates
+            requires.append("certifi")
+
 def create_mo_files():
     """Compiles .po files in local/LANG to .mo files and returns them as array of data_files"""
 
@@ -32,10 +49,6 @@ def install_certs(cmd):
     orig_run = cmd.run
 
     def run(self):
-        if platform == "darwin" and version_info >= (3, 6):
-            INSTALL_CERTS = "/Applications/Python 3.6/Install Certificates.command"
-            if not isfile(INSTALL_CERTS) or call(INSTALL_CERTS) != 0:
-                raise RuntimeError("Error installing certificates.")
         orig_run(self)
 
     cmd.run = run
@@ -63,10 +76,7 @@ setup(
     ],
     description="This is submit50, with which you can submit solutions to \
 problems for CS50.",
-    install_requires=[
-        "backports.shutil_get_terminal_size", "backports.shutil_which",
-        "pexpect>=4.0", "requests", "six", "termcolor"
-    ],
+    install_requires=requires,
     keywords=["submit", "submit50"],
     name="submit50",
     py_modules=["submit50"],

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,9 @@ requires = [
         "pexpect>=4.0", "requests", "six", "termcolor"
 ]
 
-# check whether we have a Homebrew or Python installation of Python
-INSTALL_CERTS = "/Applications/Python 3.6/Install Certificates.command"
-HOMEBREW_PYTHON = "/usr/local/bin/python3"
-
+# install certifi under OS X
 if platform == "darwin" and version_info >= (3, 6):
-    if not isfile(INSTALL_CERTS) or call(INSTALL_CERTS) != 0:
-        if not isfile(HOMEBREW_PYTHON):
-            raise RuntimeError("Install certificates not found and no Homebrew Python installed!")
-        else:
-            # certifi library installs needed certificates
-            requires.append("certifi")
+    requires.append("certifi")
 
 def create_mo_files():
     """Compiles .po files in local/LANG to .mo files and returns them as array of data_files"""
@@ -39,32 +31,6 @@ def create_mo_files():
 
     return mo_files
 
-def install_certs(cmd):
-    """
-    Decorator for classes subclassing one of setuptools commands.
-
-    Installs certificates before installing the package when running
-    Python >= 3.6 on Mac OS.
-    """
-    orig_run = cmd.run
-
-    def run(self):
-        orig_run(self)
-
-    cmd.run = run
-    return cmd
-
-
-@install_certs
-class CustomDevelop(develop):
-    pass
-
-
-@install_certs
-class CustomInstall(install):
-    pass
-
-
 setup(
     author="CS50",
     author_email="sysadmins@cs50.harvard.edu",
@@ -80,10 +46,6 @@ problems for CS50.",
     keywords=["submit", "submit50"],
     name="submit50",
     py_modules=["submit50"],
-    cmdclass={
-        "develop": CustomDevelop,
-        "install": CustomInstall
-    },
     entry_points={
         "console_scripts": ["submit50=submit50:main"]
     },


### PR DESCRIPTION
Python installed via standard launcher still supported, but Homebrew Python will now require `certifi` as a dependency so as to get certificates working either way