### PR TITLE
special characters in password fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,5 +79,5 @@ problems for CS50.",
     },
     data_files=create_mo_files(),
     url="https://github.com/cs50/submit50",
-    version="2.4.8"
+    version="2.4.9"
 )

--- a/submit50.py
+++ b/submit50.py
@@ -206,6 +206,8 @@ def authenticate(org):
                 print("*", end="")
                 sys.stdout.flush()
 
+    password = password.encode('utf8')
+
     # authenticate user
     email = "{}@users.noreply.github.com".format(username)
     res = requests.get("https://api.github.com/user",
@@ -356,7 +358,7 @@ def run(command, cwd=None, env=None, lines=[], password=None, quiet=False, timeo
     if password:
         i = child.expect(["Password for '.*': ", pexpect.EOF])
         if i == 0:
-            child.sendline(password)
+            child.sendline(password.decode('utf8'))
 
     # send lines of input
     for line in lines:

--- a/submit50.py
+++ b/submit50.py
@@ -242,7 +242,7 @@ def authenticate(org):
     timeout = int(datetime.timedelta(weeks=1).total_seconds())
     run("git -c credential.helper='cache --socket {} --timeout {}' "
         "-c credentialcache.ignoresighup=true credential approve".format(authenticate.SOCKET, timeout),
-        lines=["username={}".format(username), "password={}".format(password), "", ""],
+        lines=["username={}".format(username), "password={}".format(password.decode('utf8')), "", ""],
         quiet=True)
 
     # return credentials


### PR DESCRIPTION
Because GitHub allows non ASCII chars in passwords, make sure to encode `str` in `utf8`.