### PR TITLE
fixed version check on FreeBSD

### DIFF
--- a/submit50/__init__.py
+++ b/submit50/__init__.py
@@ -6,7 +6,7 @@ try:
     _dist = get_distribution("submit50")
     # Normalize path for cross-OS compatibility.
     _dist_loc = os.path.normcase(_dist.location)
-    _here = os.path.normcase(__file__)
+    _here = os.path.normcase(os.path.realpath(__file__))
     if not _here.startswith(os.path.join(_dist_loc, "submit50")):
         # This version is not installed, but another version is.
         raise DistributionNotFound


### PR DESCRIPTION
Resolves __file__ path to remove symbolic links.

BSDs tend to use a symbolic link for /home/ pointing to /usr/home/. 
A location comparison failed due to __file__ returning the former, and _dist the latter.

See also:
https://stackoverflow.com/questions/16484658/os-path-dirname-file-not-working-in-freebsd