### PR TITLE
add honesty prompt support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         'submit50': [('**.py', 'python', None),],
     },
     description="This is submit50, with which you can submit solutions to problems for CS50.",
-    install_requires=["lib50>=2.1,<3", "requests>=2.19", "termcolor>=1.1"],
+    install_requires=["lib50>=3,<4", "requests>=2.19", "termcolor>=1.1"],
     keywords=["submit", "submit50"],
     name="submit50",
     python_requires=">=3.6",

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -71,6 +71,7 @@ def prompt(honesty, included, excluded):
     else:
         raise Error(_("No files in this directory are expected for submission."))
 
+
     # Files that won't be submitted
     if excluded:
         cprint(_("Files that won't be submitted:"), "yellow")
@@ -80,6 +81,11 @@ def prompt(honesty, included, excluded):
     # Prompt for honesty
     if not honesty:
         return True
+
+    if honesty is True:
+        honesty = _("Keeping in mind the course's policy on "
+                    "academic honesty, are you sure you want to "
+                    "submit these files?")
 
     readline.clear_history()
 

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -63,8 +63,7 @@ def cprint(text="", color=None, on_color=None, attrs=None, **kwargs):
                      color=color, on_color=on_color, attrs=attrs, **kwargs)
 
 
-def prompt(question = "Keeping in mind the course's policy on academic honesty, "
-                         "are you sure you want to submit these files (yes/no)? ", included, excluded):
+def prompt(question, included, excluded):
     if included:
         cprint(_("Files that will be submitted:"), "green")
         for file in included:
@@ -79,9 +78,10 @@ def prompt(question = "Keeping in mind the course's policy on academic honesty, 
             cprint("./{}".format(other), "yellow")
 
     # Prompt for honesty
-    readline.clear_history()
     if not honesty:
         return True
+    
+    readline.clear_history()
     try:
         answer = input(_(question))
     except EOFError:

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -83,7 +83,7 @@ def prompt(question, included, excluded):
     
     readline.clear_history()
     try:
-        answer = input(_(question))
+        answer = input(_(question + "(yes/no) "))
     except EOFError:
         answer = None
         print()

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -83,7 +83,7 @@ def prompt(question, included, excluded):
     
     readline.clear_history()
     try:
-        answer = input(_(question + "(yes/no) "))
+        answer = input(_(question + " (yes/no) "))
     except EOFError:
         answer = None
         print()

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -82,8 +82,9 @@ def prompt(question, included, excluded):
         return True
     
     readline.clear_history()
+    
     try:
-        answer = input(_(question + " (yes/no) "))
+        answer = input(f"{_(question)} ({_('yes/no')}) ")
     except EOFError:
         answer = None
         print()

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -63,7 +63,8 @@ def cprint(text="", color=None, on_color=None, attrs=None, **kwargs):
                      color=color, on_color=on_color, attrs=attrs, **kwargs)
 
 
-def prompt(included, excluded):
+def prompt(question = "Keeping in mind the course's policy on academic honesty, "
+                         "are you sure you want to submit these files (yes/no)? ", included, excluded):
     if included:
         cprint(_("Files that will be submitted:"), "green")
         for file in included:
@@ -79,9 +80,10 @@ def prompt(included, excluded):
 
     # Prompt for honesty
     readline.clear_history()
+    if not honesty:
+        return True
     try:
-        answer = input(_("Keeping in mind the course's policy on academic honesty, "
-                         "are you sure you want to submit these files (yes/no)? "))
+        answer = input(_(question))
     except EOFError:
         answer = None
         print()

--- a/submit50/__main__.py
+++ b/submit50/__main__.py
@@ -63,7 +63,7 @@ def cprint(text="", color=None, on_color=None, attrs=None, **kwargs):
                      color=color, on_color=on_color, attrs=attrs, **kwargs)
 
 
-def prompt(question, included, excluded):
+def prompt(honesty, included, excluded):
     if included:
         cprint(_("Files that will be submitted:"), "green")
         for file in included:
@@ -80,11 +80,11 @@ def prompt(question, included, excluded):
     # Prompt for honesty
     if not honesty:
         return True
-    
+
     readline.clear_history()
-    
+
     try:
-        answer = input(f"{_(question)} ({_('yes/no')}) ")
+        answer = input(f"{_(honesty)} ({_('yes/no')}) ")
     except EOFError:
         answer = None
         print()


### PR DESCRIPTION
Update submit50 to support @crossroads1112 update of lib50.

Add extra argument to prompt, ```question```, where the user can specify a custom honesty prompt if desired or a false-y value if the user does not want any honesty prompt.