### PR TITLE
Resolve symlinks when checking version

### DIFF
--- a/submit50/__init__.py
+++ b/submit50/__init__.py
@@ -5,8 +5,8 @@ import os
 try:
     _dist = get_distribution("submit50")
     # Normalize path for cross-OS compatibility.
-    _dist_loc = os.path.normcase(_dist.location)
-    _here = os.path.normcase(__file__)
+    _dist_loc = os.path.normcase(os.path.realpath(_dist.location))
+    _here = os.path.normcase(os.path.realpath(__file__))
     if not _here.startswith(os.path.join(_dist_loc, "submit50")):
         # This version is not installed, but another version is.
         raise DistributionNotFound


### PR DESCRIPTION
When using python's venv, packages are installed under `lib/pythonX.Y/site-packages`, but `sys.path` contains `lib64/pythonX.Y/site-packages` entry (`lib64` is just a symlink to `lib`). 

Without `realpath`, `_dist_loc` is no longer a prefix of `_here`, and `submit50` fails with `You have an outdated version of submit50. Please upgrade.` . 